### PR TITLE
Fix/#40 bugfix

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,7 @@ logging:
     org.springframework: info
     com.sparta: debug
     org.springframework.security: trace
+
+jwt:
+  secret:
+    key: {{JWT_SECRET_KEY}}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,7 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password: password
+
+jwt:
+  secret:
+    key: testtest1234567890testtest1234567890testest12354567890testest123456789


### PR DESCRIPTION
dev 브랜치의 application.yml에 jwt관련 필드가 없어서 빌드가 되지 않는 문제가 생김.

dev브랜치에 있는 application.yml 파일에 jwt키 필드 추가

- This closes #40 