### PR TITLE
refactor(#134) : imageUploadPost 기능 분리

### DIFF
--- a/src/main/java/com/hobbyhop/domain/post/controller/PostController.java
+++ b/src/main/java/com/hobbyhop/domain/post/controller/PostController.java
@@ -36,10 +36,18 @@ public class PostController {
     @PostMapping
     public ApiResponse<?> makePost(@PathVariable Long clubId,
             @RequestBody @Valid PostRequestDTO postRequestDTO,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return ApiResponse.ok(postService.makePost(userDetails, clubId, postRequestDTO));
+    }
+
+    @PostMapping("/{postId}")
+    public ApiResponse<?> imageUploadPost(@PathVariable Long clubId, @PathVariable Long postId,
             @RequestParam("file") MultipartFile file,
             @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
 
-        return ApiResponse.ok(postService.makePost(userDetails, clubId, file, postRequestDTO));
+        postService.imageUploadPost(userDetails, clubId, postId, file);
+        return ApiResponse.ok("이미지 업로드 성공");
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/com/hobbyhop/domain/post/service/PostService.java
+++ b/src/main/java/com/hobbyhop/domain/post/service/PostService.java
@@ -20,8 +20,9 @@ public interface PostService {
 
     Post findPost(Long postId);
 
-    PostResponseDTO makePost(UserDetailsImpl userDetails, Long clubId, MultipartFile file, PostRequestDTO postRequestDTO)
-            throws IOException;
+    PostResponseDTO makePost(UserDetailsImpl userDetails, Long clubId, PostRequestDTO postRequestDTO);
+
+    void imageUploadPost(UserDetailsImpl userDetails, Long clubId, Long postId, MultipartFile file) throws IOException;
 
     PostResponseDTO getPostById(Long clubId, Long postId);
 
@@ -34,4 +35,6 @@ public interface PostService {
     void deletePost(UserDetailsImpl userDetails, Long clubId, Long postId);
 
     void makePostUser(UserDetailsImpl userDetails, Long clubId, Long postId);
+
+
 }

--- a/src/main/java/com/hobbyhop/domain/post/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/post/service/impl/PostServiceImpl.java
@@ -39,20 +39,13 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public PostResponseDTO makePost(UserDetailsImpl userDetails, Long clubId, MultipartFile file, PostRequestDTO postRequestDTO)
-            throws IOException {
+    public PostResponseDTO makePost(UserDetailsImpl userDetails, Long clubId, PostRequestDTO postRequestDTO) {
 
         Club club = clubService.findClub(clubId);
-
-        String originFilename = s3Service.saveFile(file);
-        String savedFilename = UUID.randomUUID() + "_" + originFilename;
-
 
         Post post = Post.builder()
                 .postTitle(postRequestDTO.getPostTitle())
                 .postContent(postRequestDTO.getPostContent())
-                .originImageUrl(originFilename)
-                .savedImageUrl(savedFilename)
                 .club(club)
                 .user(userDetails.getUser())
                 .likeCnt(0L)
@@ -62,6 +55,21 @@ public class PostServiceImpl implements PostService {
 
         return PostResponseDTO.fromEntity(post);
     }
+
+    @Override
+    @Transactional
+    public void imageUploadPost(UserDetailsImpl userDetails, Long clubId, Long postId, MultipartFile file)
+            throws IOException {
+
+        Club club = clubService.findClub(clubId);
+        Post post = findPost(postId);
+
+        String originFilename = s3Service.saveFile(file);
+        String savedFilename = UUID.randomUUID() + "_" + originFilename;
+
+        post.changeImageUrl(originFilename, savedFilename);
+    }
+
 
     @Override
     public PostResponseDTO getPostById(Long clubId, Long postId) {


### PR DESCRIPTION
- #134 
- swagger는 form-data를 받아들이지 못함. 따라서 해당 메서드 분리 
