### PR TITLE
refactor(#179) : 반환 값에 엔티티의 id를 같이 반환하도록 수정

### DIFF
--- a/src/main/java/com/hobbyhop/domain/joinrequest/dto/JoinResponseDTO.java
+++ b/src/main/java/com/hobbyhop/domain/joinrequest/dto/JoinResponseDTO.java
@@ -8,11 +8,13 @@ import lombok.Data;
 @Data
 @Builder
 public class JoinResponseDTO {
+    private Long id;
     private Long sendUserId;
     private Long recvClubId;
 
     public static JoinResponseDTO fromEntity(JoinRequest joinRequest) {
         return JoinResponseDTO.builder()
+                .id(joinRequest.getId())
                 .sendUserId(joinRequest.getUser().getId())
                 .recvClubId(joinRequest.getClub().getId())
                 .build();


### PR DESCRIPTION
- #179 
프론트엔드 작업을 하면서 가입 신청 처리를 할 때 엔티티의 아이디를 알아야하는 일이 생김. 그래서 수정함

This closes #179 