### PR TITLE
refactor(#192) : ClubRepositoryCustom

### DIFF
--- a/src/main/java/com/hobbyhop/domain/club/repository/ClubRepository.java
+++ b/src/main/java/com/hobbyhop/domain/club/repository/ClubRepository.java
@@ -1,7 +1,7 @@
 package com.hobbyhop.domain.club.repository;
 
 import com.hobbyhop.domain.club.entity.Club;
-import com.hobbyhop.domain.club.repository.search.ClubRepositoryCustom;
+import com.hobbyhop.domain.club.repository.custom.ClubRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/hobbyhop/domain/club/repository/custom/ClubRepositoryCustom.java
+++ b/src/main/java/com/hobbyhop/domain/club/repository/custom/ClubRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.hobbyhop.domain.club.repository.search;
+package com.hobbyhop.domain.club.repository.custom;
 
 import com.hobbyhop.domain.club.dto.ClubResponseDTO;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/hobbyhop/domain/club/repository/custom/impl/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/hobbyhop/domain/club/repository/custom/impl/ClubRepositoryCustomImpl.java
@@ -1,9 +1,9 @@
-package com.hobbyhop.domain.club.repository.search.impl;
+package com.hobbyhop.domain.club.repository.custom.impl;
 
 import static com.hobbyhop.domain.club.entity.QClub.club;
 
 import com.hobbyhop.domain.club.dto.ClubResponseDTO;
-import com.hobbyhop.domain.club.repository.search.ClubRepositoryCustom;
+import com.hobbyhop.domain.club.repository.custom.ClubRepositoryCustom;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
- #192 
클럽 도메인에서 Querydsl을 사용하는 레포지토리 패키지의 이름을 컨벤션에 맞추어 ClubRepositorySearch에서 ClubRepositoryCustom으로 변경함.

This closes #192 