### PR TITLE
Feature/#266 user info

### DIFF
--- a/src/main/java/com/hobbyhop/domain/user/dto/SignupRequestDTO.java
+++ b/src/main/java/com/hobbyhop/domain/user/dto/SignupRequestDTO.java
@@ -23,9 +23,8 @@ public class SignupRequestDTO {
 			max = 50)
 	private String email;
 
-	@NotBlank(message = "info : 자기소개를 3~50자 입력해주세요.")
-	@Size(	min = 3,
-			max = 50)
+	@Size(	max = 50,
+			message = "info : 자기소개를 50자 미만으로 입력해주세요.")
 	private String info;
 
 	@NotBlank(message = "password : 비밀번호를 입력해주세요.")

--- a/src/main/java/com/hobbyhop/domain/user/entity/User.java
+++ b/src/main/java/com/hobbyhop/domain/user/entity/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
     @Column(length = 50, nullable = false, unique = true)
     private String email;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 50)
     private String info;
 
     @Column(length = 100, nullable = false)


### PR DESCRIPTION
회원 가입 시 자기소개 필드(info) 받아도 되고 안 받아도 되는 걸로 수정했습니다.
사진은 포스트맨으로 회원 가입 테스트했을 때 info 필드에 null(필드 제거), 공백(필드에 ""), 텍스트를 입력했을 때 각각의 경우입니다.
![image](https://github.com/hobby-hop/hobby-hop/assets/148298032/3750ba52-5170-4bc8-b363-8d521c45256b)
