### PR TITLE
Refactor/#282 user refactoring

### DIFF
--- a/src/main/java/com/hobbyhop/domain/user/dto/SignupRequestDTO.java
+++ b/src/main/java/com/hobbyhop/domain/user/dto/SignupRequestDTO.java
@@ -10,7 +10,7 @@ public class SignupRequestDTO {
 
 	@NotBlank(message = "username : 이름을 입력해주세요.")
 	@Pattern(regexp = "^[a-zA-Z0-9가-힣]+$",
-			 message = "username : 한글, 영어, 숫자만 입력해야 합니다.")
+			message = "username : 한글, 영어, 숫자만 입력해야 합니다.")
 	@Size(	min = 1,
 			max = 12,
 			message = "username : 이름은 최소 1자 이상, 최대 12자 이하로 입력해야 합니다.")
@@ -18,7 +18,7 @@ public class SignupRequestDTO {
 
 	@NotBlank(message = "email : 이메일을 입력해주세요.")
 	@Pattern(regexp = "^(?:\\w+\\.?)*\\w+@(?:\\w+\\.)+\\w+$",
-			 message = "email : 이메일 형식이 올바르지 않습니다.")
+			message = "email : 이메일 형식이 올바르지 않습니다.")
 	@Size(	min = 7,
 			max = 50)
 	private String email;
@@ -29,7 +29,7 @@ public class SignupRequestDTO {
 
 	@NotBlank(message = "password : 비밀번호를 입력해주세요.")
 	@Pattern(regexp = "^[a-zA-Z0-9]+$",
-			 message = "password : 비밀번호는 알파벳 대소문자, 숫자의 조합으로 입력해야 합니다.")
+			message = "password : 비밀번호는 알파벳 대소문자, 숫자의 조합으로 입력해야 합니다.")
 	@Size(	min = 8,
 			max = 15,
 			message = "password : 비밀번호는 8자리 이상, 15자리 이하로 입력해야 합니다.")

--- a/src/main/java/com/hobbyhop/domain/user/dto/UpdateProfileRequestDTO.java
+++ b/src/main/java/com/hobbyhop/domain/user/dto/UpdateProfileRequestDTO.java
@@ -1,8 +1,5 @@
 package com.hobbyhop.domain.user.dto;
 
-import com.hobbyhop.domain.user.dto.validCustom.NullablePattern;
-
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -95,12 +95,9 @@ public class UserServiceImpl implements UserService {
         return MyProfileResponseDTO.fromEntity(user);
     }
 
-
     @Override
     public OtherProfileResponseDTO getOtherProfile(Long otherUserId, UserDetailsImpl userDetails, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) {
-        User user = userRepository.findById(otherUserId)
-            .orElseThrow(NotFoundUserException::new);
-
+        User user = getUserById(userDetails.getUser().getId());
         return OtherProfileResponseDTO.fromEntity(user);
     }
 

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -39,21 +39,17 @@ public class UserServiceImpl implements UserService {
             throw new DuplicateEntryException();
         }
     }
-
-
+    
     @Override
     public void login(LoginRequestDTO loginRequestDTO, HttpServletResponse response) {
-        String email = loginRequestDTO.getEmail();
-        String password = loginRequestDTO.getPassword();
-
-        User user = userRepository.findByEmail(email)
-            .orElseThrow(NotFoundUserException::new);
+        User user = userRepository.findByEmail(loginRequestDTO.getEmail())
+                .orElseThrow(NotFoundUserException::new);
         String username = user.getUsername();
 
-        validatePassword(user, password);
+        validatePassword(user, loginRequestDTO.getPassword());
 
         String accessToken = jwtUtil.createAccessToken(username);
-        response.setHeader("Authorization", accessToken);
+        response.setHeader(AUTHORIZATION_HEADER, accessToken);
         jwtUtil.saveAccessTokenByUsername(username, accessToken);
 
         String refreshToken = jwtUtil.createRefreshToken(username);

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -31,23 +31,15 @@ public class UserServiceImpl implements UserService {
     @Override
     public void signup(SignupRequestDTO signupRequestDTO) {
         try {
-            deletedUserVerification(signupRequestDTO);
+            withdrawnUserVerification(signupRequestDTO);
             validateExistingUser(signupRequestDTO);
-
-            User user = User.builder()
-                .username(signupRequestDTO.getUsername())
-                .password(passwordEncoder.encode(signupRequestDTO.getPassword()))
-                .email(signupRequestDTO.getEmail())
-                .info(signupRequestDTO.getInfo())
-                .role(UserRoleEnum.USER)
-                .build();
-
+            User user = signupUser(signupRequestDTO);
             userRepository.save(user);
-        }
-        catch (DataIntegrityViolationException e) {
+        } catch (DataIntegrityViolationException e) {
             throw new DuplicateEntryException();
         }
     }
+
 
     @Override
     public void login(LoginRequestDTO loginRequestDTO, HttpServletResponse response) {

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -215,4 +215,23 @@ public class UserServiceImpl implements UserService {
                 .build();
     }
 
+    // 회원가입 메서드 2 - 탈퇴한 사용자인지 확인
+    private void withdrawnUserVerification(SignupRequestDTO signupRequestDTO) {
+        if (userRepository.existsByEmailAndDeletedAtIsNull(signupRequestDTO.getEmail())) {
+            throw new AlreadyExistEmailException();
+        }
+
+        if (userRepository.existsByEmailAndDeletedAtIsNotNull(signupRequestDTO.getEmail())) {
+            throw new NotAvailableEmailException();
+        }
+
+        if (userRepository.existsByUsernameAndDeletedAtIsNull(signupRequestDTO.getUsername())) {
+            throw new AlreadyExistUsernameException();
+        }
+
+        if (userRepository.existsByUsernameAndDeletedAtIsNotNull(signupRequestDTO.getUsername())) {
+            throw new NotAvailableUsernameException();
+        }
+    }
+
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -158,12 +158,6 @@ public class UserServiceImpl implements UserService {
         httpServletResponse.setHeader(JwtUtil.AUTHORIZATION_HEADER, newAccessToken);
     }
 
-    private void validatePassword(User user, String password) {
-        if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new MismatchedPasswordException();
-        }
-    }
-
     private void deletedUserVerification (SignupRequestDTO signupRequestDTO) {
         if (userRepository.existsByEmailAndDeletedAtIsNull(signupRequestDTO.getEmail())) {
             throw new AlreadyExistEmailException();
@@ -203,5 +197,10 @@ public class UserServiceImpl implements UserService {
         return userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
     }
 
-
+    // 공통 메서드 2 - 비밀번호 일치하는지 확인
+    private void validatePassword(User user, String password) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new MismatchedPasswordException();
+        }
+    }
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -230,6 +230,17 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    // 유저 정보 수정 메서드 2 - 액세스 토큰 새로 발급
+    private void updateAccessToken(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, User user) {
+        String requestHeaderAccessToken = httpServletRequest.getHeader(AUTHORIZATION_HEADER); // 현재 액세스 토큰을 헤더에서 가져오기
+        String newAccessToken = jwtUtil.createAccessToken(user.getUsername()); // username 으로 새 액세스 토큰 생성
 
-
+        if (jwtUtil.validateToken(requestHeaderAccessToken.substring(7))) { // 현재 액세스 토큰이 유효한지 확인
+            jwtUtil.rebaseToken(newAccessToken, requestHeaderAccessToken); // 유효하면 새 액세스 토큰으로 업데이트
+        } else {
+            String responseHeaderAccessToken = httpServletResponse.getHeader(AUTHORIZATION_HEADER);
+            jwtUtil.rebaseToken(newAccessToken, responseHeaderAccessToken); // 유효하지 않으면 헤더 액세스 토큰으로 업데이트
+        }
+        httpServletResponse.setHeader(AUTHORIZATION_HEADER, newAccessToken); // 헤더에 새 액세스 토큰 set하기
+    }
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -39,7 +39,7 @@ public class UserServiceImpl implements UserService {
             throw new DuplicateEntryException();
         }
     }
-    
+
     @Override
     public void login(LoginRequestDTO loginRequestDTO, HttpServletResponse response) {
         User user = userRepository.findByEmail(loginRequestDTO.getEmail())
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void withdraw(WithdrawalRequestDTO withdrawalRequestDTO, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
-        String accessToken = httpServletRequest.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+        String accessToken = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
 
         if (accessToken == null || !jwtUtil.validateToken(accessToken.substring(7))) {
             throw new InvalidJwtException();
@@ -78,7 +78,7 @@ public class UserServiceImpl implements UserService {
         String username = claims.getSubject();
 
         User user = userRepository.findByUsername(username)
-            .orElseThrow(NotFoundUserException::new);
+                .orElseThrow(NotFoundUserException::new);
 
         validatePassword(user, withdrawalRequestDTO.getPassword());
 
@@ -86,7 +86,7 @@ public class UserServiceImpl implements UserService {
         jwtUtil.removeRefreshToken(accessToken);
         userRepository.delete(user);
 
-        httpServletResponse.setHeader(jwtUtil.AUTHORIZATION_HEADER, "withdrawal");
+        httpServletResponse.setHeader(AUTHORIZATION_HEADER, "withdrawal");
     }
 
     @Override

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -226,4 +226,13 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    // 로그아웃 메서드
+    private void processToken(String token) {
+        if (token != null && jwtUtil.validateToken(token.substring(7))) {
+            jwtUtil.removeAccessToken(token);
+            jwtUtil.removeRefreshToken(token);
+        }
+    }
+
+
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -91,11 +91,10 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public MyProfileResponseDTO getMyProfile(UserDetailsImpl userDetails, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) {
-        User user = userRepository.findById(userDetails.getUser().getId())
-            .orElseThrow(NotFoundUserException::new);
-
+        User user = getUserById(userDetails.getUser().getId());
         return MyProfileResponseDTO.fromEntity(user);
     }
+
 
     @Override
     public OtherProfileResponseDTO getOtherProfile(Long otherUserId, UserDetailsImpl userDetails, HttpServletResponse httpServletResponse, HttpServletRequest httpServletRequest) {

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -62,20 +62,13 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void logout(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
-        String accessToken = httpServletRequest.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+        String accessToken = httpServletRequest.getHeader(AUTHORIZATION_HEADER);
+        processToken(accessToken);
 
-        if (accessToken != null && jwtUtil.validateToken(accessToken.substring(7))) {
-            jwtUtil.removeAccessToken(accessToken);
-            jwtUtil.removeRefreshToken(accessToken);
-        } else {
-            String responseHeaderAccessToken = httpServletResponse.getHeader(JwtUtil.AUTHORIZATION_HEADER);
+        String responseHeaderAccessToken = httpServletResponse.getHeader(AUTHORIZATION_HEADER);
+        processToken(responseHeaderAccessToken);
 
-            if (responseHeaderAccessToken != null) {
-                jwtUtil.removeAccessToken(responseHeaderAccessToken);
-                jwtUtil.removeRefreshToken(responseHeaderAccessToken);
-            }
-        }
-        httpServletResponse.setHeader(JwtUtil.AUTHORIZATION_HEADER, "logged-out");
+        httpServletResponse.setHeader(AUTHORIZATION_HEADER, "logged-out");
     }
 
     @Override

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -176,21 +176,6 @@ public class UserServiceImpl implements UserService {
         }
     }
 
-    private void validateExistingUser (SignupRequestDTO signupRequestDTO) {
-        if (userRepository.existsByUsername(signupRequestDTO.getUsername())) {
-            throw new NotAvailableUsernameException();
-        }
-
-        if (userRepository.existsByEmail(signupRequestDTO.getEmail())) {
-            throw new NotAvailableEmailException();
-        }
-
-        if (!signupRequestDTO.getConfirmPassword().equals(signupRequestDTO.getPassword())) {
-            throw new MismatchedPasswordException();
-        }
-    }
-
-
     //===================================================================================================
     // 공통 메서드 1 - 유저 저장
     private User getUserById(Long userId) {
@@ -231,6 +216,21 @@ public class UserServiceImpl implements UserService {
 
         if (userRepository.existsByUsernameAndDeletedAtIsNotNull(signupRequestDTO.getUsername())) {
             throw new NotAvailableUsernameException();
+        }
+    }
+
+    // 회원가입 메서드 3 - 존재하는 유저인지 확인
+    private void validateExistingUser(SignupRequestDTO signupRequestDTO) {
+        if (userRepository.existsByUsername(signupRequestDTO.getUsername())) {
+            throw new NotAvailableUsernameException();
+        }
+
+        if (userRepository.existsByEmail(signupRequestDTO.getEmail())) {
+            throw new NotAvailableEmailException();
+        }
+
+        if (!signupRequestDTO.getConfirmPassword().equals(signupRequestDTO.getPassword())) {
+            throw new MismatchedPasswordException();
         }
     }
 

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -219,5 +219,17 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    // 유저 정보 수정 메서드 1  - 비밀번호 변경
+    private void validateNewPassword(String oldPassword, String newPassword, String confirmPassword) {
+        if (newPassword.equals(oldPassword)) { // 새 비밀번호와 예전 비밀번호가 같다면 예외 처리
+            throw new MatchedPasswordException();
+        }
+
+        if (!newPassword.equals(confirmPassword)) { // 새 비밀번호와 확인용 비밀번호가 다르다면 예외 처리
+            throw new MismatchedNewPasswordException();
+        }
+    }
+
+
 
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -26,6 +26,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
+    private static final String AUTHORIZATION_HEADER = JwtUtil.AUTHORIZATION_HEADER;
 
     @Override
     public void signup(SignupRequestDTO signupRequestDTO) {

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -203,4 +203,16 @@ public class UserServiceImpl implements UserService {
             throw new MismatchedPasswordException();
         }
     }
+
+    // 회원가입 메서드 1 - 회원가입 빌더
+    private User signupUser(SignupRequestDTO signupRequestDTO) {
+        return User.builder()
+                .username(signupRequestDTO.getUsername())
+                .password(passwordEncoder.encode(signupRequestDTO.getPassword()))
+                .email(signupRequestDTO.getEmail())
+                .info(signupRequestDTO.getInfo())
+                .role(UserRoleEnum.USER)
+                .build();
+    }
+
 }

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -119,25 +119,6 @@ public class UserServiceImpl implements UserService {
         updateAccessToken(httpServletRequest, httpServletResponse, user);
     }
 
-
-    private void deletedUserVerification (SignupRequestDTO signupRequestDTO) {
-        if (userRepository.existsByEmailAndDeletedAtIsNull(signupRequestDTO.getEmail())) {
-            throw new AlreadyExistEmailException();
-        }
-
-        if (userRepository.existsByEmailAndDeletedAtIsNotNull(signupRequestDTO.getEmail())) {
-            throw new NotAvailableEmailException();
-        }
-
-        if (userRepository.existsByUsernameAndDeletedAtIsNull(signupRequestDTO.getUsername())) {
-            throw new AlreadyExistUsernameException();
-        }
-
-        if (userRepository.existsByUsernameAndDeletedAtIsNotNull(signupRequestDTO.getUsername())) {
-            throw new NotAvailableUsernameException();
-        }
-    }
-
     //===================================================================================================
     // 공통 메서드 1 - 유저 저장
     private User getUserById(Long userId) {

--- a/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/hobbyhop/domain/user/service/impl/UserServiceImpl.java
@@ -195,4 +195,13 @@ public class UserServiceImpl implements UserService {
             throw new MismatchedPasswordException();
         }
     }
+
+
+    //===================================================================================================
+    // 공통 메서드 1 - 유저 저장
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
+    }
+
+
 }


### PR DESCRIPTION
포스트맨으로 테스트 완료했습니다.

1. **로그인, 로그아웃, 회원 탈퇴, 액세스 토큰 새로 발급하는 메서드**
상수 AUTHORIZATION_HEADER 를 사용하여 "Authorization" 헤더 이름을 하드 코딩하지 않도록 변경했습니다.

2. **회원 가입, 로그아웃, 유저 정보 수정, 내 프로필 조회, 다른 유저 프로필 조회**
메서드 추출로 토큰 검증 및 처리 중복 코드 제거했습니다. 

수정하면서 자꾸 헷갈려서 주석으로 메서드에 번호 붙였어요...^^🥹
